### PR TITLE
Remove vendor from dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,4 @@
 /.git
-/vendor
 /hack
 /contour
 *.test


### PR DESCRIPTION
Re-add `vendor/` to the build context